### PR TITLE
chore: upgrade pnpm to 11.15.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,5 +80,5 @@
     "watch:storybook": "lerna run build:stencil && lerna run build:style-dictionary && pnpm --filter ./packages/storybook run storybook",
     "watch:style-dictionary": "lerna run watch:style-dictionary"
   },
-  "packageManager": "pnpm@11.5.2+sha512.71c631e382066efc25625d5cf029075de07b61b37f6e27350fbd84b1bda5864c8c1967adc280776b45c30a715c0359a3be08fef42d5bb09e2b99029979692916"
+  "packageManager": "pnpm@11.15.1+sha512.81350b07e53c9538a02f1f2303b4290fa2d7be04e56e2a970c4cc4b417dc761de196edabd49d55c7dc9580db81007c44143e4e3d7e462b3000d23c255122d065"
 }


### PR DESCRIPTION
This PR upgrades pnpm to the latest version.  We currently pin 11.5 but there has been a lot of development since then.  Check out their [changelogs](https://pnpm.io/blog/releases/11.6).  Notable changes are minor security improvements and a bugfix that affected [lux](https://github.com/nl-design-system/lux/pull/650).
