### PR TITLE
build: restore pnpm pack/pnpm publish behavior to pre-pnpm@11.13 behavior

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+# Files listed here are excluded from the published package.
+# Keep this file even when empty; otherwise npm uses .gitignore during publish.


### PR DESCRIPTION
Since pnpm 11.13, `pnpm publish` (to be exact, `pnpm pack`) falls back to reading `.gitignore` when `.npmignore` does not exist.  This may result in dist folders no longer being included in a package.  An empty `.npmignore` restores old behavior (while keeping newer pnpm version).

More info: https://github.com/nl-design-system/beheer/issues/95
